### PR TITLE
Added week profile selection and fixes a few bugs

### DIFF
--- a/bundles/org.openhab.binding.nobohub/README.md
+++ b/bundles/org.openhab.binding.nobohub/README.md
@@ -155,7 +155,9 @@ both sets temperature level and profile.
 Get list of profile id's and names either from the logs or adding item Nobo_Hub_WeekProfiles to a sitemap. As the string
 can be quite long, using the logs are recommended. Now map the id="Profile name" to a switch og selection like this
 
+
 ### nobo.sitemap
+
 ```
 sitemap nobo label="Nobø " {
 

--- a/bundles/org.openhab.binding.nobohub/README.md
+++ b/bundles/org.openhab.binding.nobohub/README.md
@@ -9,7 +9,7 @@ mode of the hub.
 
 This binding is tested with the following devices:
 
-* Thermostats for differen electrical ovens
+* Thermostats for different electrical panel heaters
 * Nobø Switch SW 4
 
 TODO:
@@ -69,8 +69,52 @@ Not all devices report this.
 
 ## Full Example
 
-The author has just used the Paper UI to configure the system. If anybody has example file that can be included 
-here, please send it to the author.
+### nobo.things
+
+```
+Bridge nobohub:nobohub:controller "Nobø Hub" [ hostName="192.168.1.10", serialNumber="SERIAL_NUMBER" ] {
+	Thing zone 1                             "Zone - Kitchen"            	[ id=1 ]
+	Thing component SERIAL_NUMBER_COMPONENT  "Ovn - Kitchen"         		[ serialNumber="SERIAL_NUMBER_COMPONENT" ]
+}
+```
+
+### nobo.items
+
+```
+// Hub
+String	Nobo_Hub_GlobalOverride         "Global Override %s"                <heating>       {channel="nobohub:nobohub:controller:activeOverrideName"}
+
+// Panel Heater
+Number	PanelHeater_CurrentTemperatur   "Setpoint [%.1f °C]"                <temperature>   {channel="nobohub:component:controller:SERIAL_NUMBER_COMPONENT:currentTemperature"}
+
+// Zone
+String	Zone_WeekProfileActive          "Active week profile [%s]"          <calendar>      {channel="nobohub:zone:controller:1:activeWeekProfile"}
+String	Zone_WeekProfileStatus          "Active Override %s]"               <heating>       {channel="nobohub:zone:controller:1:calculatedWeekProfileStatus"}
+Number	Zone_ComfortTemperatur          "Comfort temperature [%.1f °C]"     <temperature>   {channel="nobohub:zone:controller:1:comfortTemperature"}
+Number	Zone_EcoTemperatur              "Eco temperature [%.1f °C]"         <temperature>   {channel="nobohub:zone:controller:1:ecoTemperature"}
+Number	Zone_CurrentTemperatur          "Current temperature [%.1f °C]"     <temperature>   {channel="nobohub:zone:controller:1:currentTemperature"}
+```
+
+### nobo.sitemap
+
+```
+sitemap nobo label="Nobø " {
+
+    Frame label="Hub"{
+      Switch   item=Nobo_Hub_GlobalOverride
+    }
+
+    Frame label="Main Bedroom"{
+      Switch    item=Zone_ActiveOverride
+      Text      item=Zone_WeekProfil           
+      Setpoint  item=Zone_ComfortTemperatur minValue=7 maxValue=30 step=1 icon="temperature"
+      Setpoint  item=Zone_EcoTemperatur     minValue=7 maxValue=30 step=1 icon="temperature"
+      Text      item=Zone_CurrentTemperatur
+      Text      item=PanelHeater_CurrentTemperatur
+    }
+}
+```
+
 
 ## Bugs and logging
 

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBindingConstants.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBindingConstants.java
@@ -59,9 +59,11 @@ public class NoboHubBindingConstants {
 
     // Hub
     public static final String CHANNEL_HUB_ACTIVE_OVERRIDE_NAME = "activeOverrideName";
+    public static final String CHANNEL_HUB_WEEK_PROFILES = "weekProfiles";
 
     // Zone
-    public static final String CHANNEL_ZONE_WEEK_PROFILE_NAME = "activeWeekProfile";
+    public static final String CHANNEL_ZONE_ACTIVE_WEEK_PROFILE_NAME = "activeWeekProfileName";
+    public static final String CHANNEL_ZONE_ACTIVE_WEEK_PROFILE = "activeWeekProfile";
     public static final String CHANNEL_ZONE_CALCULATED_WEEK_PROFILE_STATUS = "calculatedWeekProfileStatus";
     public static final String CHANNEL_ZONE_COMFORT_TEMPERATURE = "comfortTemperature";
     public static final String CHANNEL_ZONE_ECO_TEMPERATURE = "ecoTemperature";
@@ -83,26 +85,26 @@ public class NoboHubBindingConstants {
 
     // Mappings
 
-    public static final Map<String, String> REJECT_REASONS = Stream.of(new String[][] { 
-        { "0", "Client command set too old, run it in with debug logs and let the maintainer know" }, 
+    public static final Map<String, String> REJECT_REASONS = Stream.of(new String[][] {
+        { "0", "Client command set too old, run it in with debug logs and let the maintainer know" },
         { "1", "Hub serial number mismatch (should be 12 digits, if hub was autodetected, plase add the last three)" },
-        { "2", "Wrong number of arguments, run it in with debug logs and let the maintainer know" }, 
-        { "3", "Timestamp incorrectly formatted, run it in with debug logs and let the maintainer know" }, 
+        { "2", "Wrong number of arguments, run it in with debug logs and let the maintainer know" },
+        { "3", "Timestamp incorrectly formatted, run it in with debug logs and let the maintainer know" },
     }).collect(Collectors.collectingAndThen(
-        Collectors.toMap(data -> data[0], data -> data[1]), 
+        Collectors.toMap(data -> data[0], data -> data[1]),
         Collections::<String, String> unmodifiableMap));
 
     // Full list of units: http://help.nobo.no/skriver/?chapterid=344&chapterlanguageid=2
-    public static final Map<String, String> SERIALNUMBERS_FOR_TYPES = Stream.of(new String[][] { 
-            { "120", "RS-700" }, 
+    public static final Map<String, String> SERIALNUMBERS_FOR_TYPES = Stream.of(new String[][] {
+            { "120", "RS-700" },
             { "168", "NCU-2R" },
             { "184", "NCU-1R" },
             { "186", "NTD-4R" },
-            { "192", "TXF" }, 
-            { "198", "NCU-ER" }, 
-            { "210", "NTB-2R" }, 
-            { "234", "Nobø Switch" }, 
+            { "192", "TXF" },
+            { "198", "NCU-ER" },
+            { "210", "NTB-2R" },
+            { "234", "Nobø Switch" },
         }).collect(Collectors.collectingAndThen(
-            Collectors.toMap(data -> data[0], data -> data[1]), 
+            Collectors.toMap(data -> data[0], data -> data[1]),
             Collections::<String, String> unmodifiableMap));
 }

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBridgeHandler.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBridgeHandler.java
@@ -17,6 +17,7 @@ import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.*;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
@@ -217,6 +218,23 @@ public class NoboHubBridgeHandler extends BaseBridgeHandler {
         if (null != activeOverride) {
             Override o = Helpers.castToNonNull(activeOverride, "activeOverride");
             updateState(NoboHubBindingConstants.CHANNEL_HUB_ACTIVE_OVERRIDE_NAME, StringType.valueOf(o.getMode().name()));
+        }
+
+
+        if(weekProfileRegister.size() > 0){
+            String mapOfWeekProfilesToString = weekProfileRegister.values()
+                    .stream()
+                    .map(weekProfile -> weekProfile.getId() + "=\"" + weekProfile.getName() + "\"")
+                    .collect(Collectors.joining(", "));
+            logger.info("Found profiles: {}", mapOfWeekProfilesToString);
+
+            Bridge noboHub = getBridge();
+            if (null != noboHub) {
+                NoboHubBridgeHandler hubHandler = (NoboHubBridgeHandler) noboHub.getHandler();
+                if (hubHandler != null) {
+                    updateState(NoboHubBindingConstants.CHANNEL_HUB_WEEK_PROFILES, StringType.valueOf(mapOfWeekProfilesToString));
+                }
+            }
         }
 
         // Update all zones to set online status and update profile name from weekProfileRegister

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBridgeHandler.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBridgeHandler.java
@@ -219,6 +219,11 @@ public class NoboHubBridgeHandler extends BaseBridgeHandler {
             updateState(NoboHubBindingConstants.CHANNEL_HUB_ACTIVE_OVERRIDE_NAME, StringType.valueOf(o.getMode().name()));
         }
 
+        // Update all zones to set online status and update profile name from weekProfileRegister
+        for (Zone zone : zoneRegister.values()) {
+            refreshZone(zone);
+        }
+
         updateProperty("name", hub.getName());
         updateProperty("serialNumber", hub.getSerialNumber().toString());
         updateProperty("softwareVersion", hub.getSoftwareVersion());

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/connection/HubCommunicationThread.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/connection/HubCommunicationThread.java
@@ -73,6 +73,7 @@ public class HubCommunicationThread extends Thread {
                     Duration readTime = Duration.between(LocalDateTime.now(), lastTimeReadStart);
                     Thread.sleep(NoboHubBindingConstants.TIME_BETWEEN_RETRIES_ON_ERROR.minus(readTime).toMillis());
                     try {
+                        logger.debug("Trying to do a hard reconnect");
                         hubConnection.hardReconnect();
                     } catch (NoboCommunicationException nce2) {
                         logger.error("Failed to reconnect connection", nce2);

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/connection/HubConnection.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/connection/HubConnection.java
@@ -55,8 +55,8 @@ public class HubConnection {
     private @Nullable PrintWriter out;
     private @Nullable BufferedReader in;
 
-
-    public HubConnection(String hostName, String serialNumber, NoboHubBridgeHandler hubHandler) throws NoboCommunicationException {
+    public HubConnection(String hostName, String serialNumber, NoboHubBridgeHandler hubHandler)
+            throws NoboCommunicationException {
         try {
             host = InetAddress.getByName(hostName);
         } catch (IOException ioex) {
@@ -70,20 +70,24 @@ public class HubConnection {
     public boolean connect() throws NoboCommunicationException {
         connectSocket();
 
-        String hello = String.format("HELLO %s %s %s\r", NoboHubBindingConstants.API_VERSION, serialNumber, getDateString());
+        String hello = String.format("HELLO %s %s %s\r", NoboHubBindingConstants.API_VERSION, serialNumber,
+                getDateString());
         write(hello);
-        @Nullable String helloRes = readLine();
+        @Nullable
+        String helloRes = readLine();
         if (null == helloRes || !helloRes.startsWith("HELLO")) {
             if (helloRes != null && helloRes.startsWith("REJECT")) {
                 String reject[] = helloRes.split(" ", 2);
-                throw new NoboCommunicationException(String.format("Hub rejects us with reason %s: %s", reject[1], NoboHubBindingConstants.REJECT_REASONS.get(reject[1])));
+                throw new NoboCommunicationException(String.format("Hub rejects us with reason %s: %s", reject[1],
+                        NoboHubBindingConstants.REJECT_REASONS.get(reject[1])));
             } else {
                 throw new NoboCommunicationException(String.format("Hub rejects us with unknown reason"));
             }
         }
 
         write("HANDSHAKE\r");
-        @Nullable String handshakeRes = readLine();
+        @Nullable
+        String handshakeRes = readLine();
         if (null == handshakeRes || !handshakeRes.startsWith("HANDSHAKE")) {
             throw new NoboCommunicationException(String.format("Hub rejects handshake"));
         }
@@ -107,7 +111,8 @@ public class HubConnection {
 
         Override override = Override.fromMode(nextMode, LocalDateTime.now());
         sendCommand(override.generateCommandString("A03"));
-        @Nullable String line = "";
+        @Nullable
+        String line = "";
         while (line != null && !line.startsWith("B03")) {
             line = readLine();
             hubHandler.receivedData(line);
@@ -132,7 +137,8 @@ public class HubConnection {
     private void refreshAllNoReconnect() throws NoboCommunicationException {
         write("G00\r");
 
-        @Nullable String line = "";
+        @Nullable
+        String line = "";
         while (line != null && !line.startsWith("H05")) {
             line = readLine();
             hubHandler.receivedData(line);
@@ -168,11 +174,13 @@ public class HubConnection {
             }
 
             Socket conn = Helpers.castToNonNull(hubConnection, "hubConnection");
-            logger.debug("Reading from Hub, waiting maximum {}", DurationFormatUtils.formatDuration(timeout.toMillis(), "H:mm:ss", true));
+            logger.debug("Reading from Hub, waiting maximum {}",
+                    DurationFormatUtils.formatDuration(timeout.toMillis(), "H:mm:ss", true));
             conn.setSoTimeout((int) timeout.toMillis());
 
             try {
-                @Nullable String line = readLine();
+                @Nullable
+                String line = readLine();
                 if (line != null && line.startsWith("HANDSHAKE")) {
                     line = readLine();
                 }
@@ -223,7 +231,8 @@ public class HubConnection {
             in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
             hubConnection = conn;
         } catch (IOException ioex) {
-            throw new NoboCommunicationException(String.format("Failed connecting to Nobø Hub at %s", host.getHostName()), ioex);
+            throw new NoboCommunicationException(
+                    String.format("Failed connecting to Nobø Hub at %s", host.getHostName()), ioex);
         }
     }
 

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/connection/HubConnection.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/connection/HubConnection.java
@@ -23,6 +23,7 @@ import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
+import org.apache.commons.lang.time.DurationFormatUtils;
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 import org.openhab.binding.nobohub.internal.Helpers;
@@ -167,7 +168,7 @@ public class HubConnection {
             }
 
             Socket conn = Helpers.castToNonNull(hubConnection, "hubConnection");
-            logger.debug("Reading from Hub, waiting maximum {}", timeout);
+            logger.debug("Reading from Hub, waiting maximum {}", DurationFormatUtils.formatDuration(timeout.toMillis(), "H:mm:ss", true));
             conn.setSoTimeout((int) timeout.toMillis());
 
             try {
@@ -246,7 +247,7 @@ public class HubConnection {
 
     public void hardReconnect() throws NoboCommunicationException {
         disconnect();
-        connectSocket();
+        connect();
     }
 
     private String getDateString() {

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/discovery/NoboThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/discovery/NoboThingDiscoveryService.java
@@ -1,22 +1,26 @@
 /**
  * Copyright (c) 2010-2020 Contributors to the openHAB project
- *
+ * <p>
  * See the NOTICE file(s) distributed with this work for additional
  * information.
- *
+ * <p>
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0
- *
+ * <p>
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.binding.nobohub.internal.discovery;
 
-import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.*;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.AUTODISCOVERED_THING_TYPES_UIDS;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.THING_TYPE_COMPONENT;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.THING_TYPE_ZONE;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.VENDOR;
 
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
@@ -24,7 +28,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.eclipse.smarthome.config.discovery.AbstractDiscoveryService;
 import org.eclipse.smarthome.config.discovery.DiscoveryResult;
 import org.eclipse.smarthome.config.discovery.DiscoveryResultBuilder;
-import org.eclipse.smarthome.core.thing.ThingTypeUID;
+import org.eclipse.smarthome.core.thing.Thing;
 import org.eclipse.smarthome.core.thing.ThingUID;
 import org.openhab.binding.nobohub.internal.NoboHubBridgeHandler;
 import org.openhab.binding.nobohub.internal.model.Component;
@@ -66,55 +70,76 @@ public class NoboThingDiscoveryService extends AbstractDiscoveryService {
 
     public void detectZones(Collection<Zone> zones) {
         ThingUID bridge = bridgeHandler.getThing().getUID();
-        ThingTypeUID thingType = THING_TYPE_ZONE;
+        List<Thing> things = bridgeHandler.getThing().getThings();
 
         for (Zone zone : zones) {
-            ThingUID thingId = new ThingUID(thingType, bridge, Integer.toString(zone.getId()));
-            String label = zone.getName();
+            ThingUID discoveredThingId = new ThingUID(THING_TYPE_ZONE, bridge, Integer.toString(zone.getId()));
 
-            Map<String, Object> properties = new HashMap<>(1);
-            properties.put("id", Integer.toString(zone.getId()));
-            properties.put("name", zone.getName());
-            properties.put("vendor", VENDOR);
+            boolean addDiscoveredZone = true;
+            for (Thing thing : things) {
+                if (thing.getUID().equals(discoveredThingId)) {
+                    addDiscoveredZone = false;
+                }
+            }
 
-            logger.debug("Adding device {} to inbox", thingId);
-            DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingId).withBridge(bridge)
-                    .withLabel(label).withProperties(properties).withRepresentationProperty("id").build();
-            thingDiscovered(discoveryResult);
+            if (addDiscoveredZone) {
+                String label = zone.getName();
+
+                Map<String, Object> properties = new HashMap<>(1);
+                properties.put("id", Integer.toString(zone.getId()));
+                properties.put("name", zone.getName());
+                properties.put("vendor", VENDOR);
+
+                logger.debug("Adding device {} to inbox", discoveredThingId);
+                DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(discoveredThingId).withBridge(bridge)
+                        .withLabel(label).withProperties(properties).withRepresentationProperty("id").build();
+                thingDiscovered(discoveryResult);
+            }
         }
     }
 
     public void detectComponents(Collection<Component> components) {
         ThingUID bridge = bridgeHandler.getThing().getUID();
-        ThingTypeUID thingType = THING_TYPE_COMPONENT;
+        List<Thing> things = bridgeHandler.getThing().getThings();
 
         for (Component component : components) {
-            ThingUID thingId = new ThingUID(thingType, bridge, component.getSerialNumber().toString());
-            String label = component.getName();
+            ThingUID discoveredThingId = new ThingUID(THING_TYPE_COMPONENT, bridge,
+                    component.getSerialNumber().toString());
 
-            Map<String, Object> properties = new HashMap<>(1);
-            properties.put("serialNumber", component.getSerialNumber().toString());
-            properties.put("name", component.getName());
-            properties.put("vendor", VENDOR);
-            properties.put("model", component.getSerialNumber().getComponentType());
-
-            String zoneName = getZoneName(component.getZoneId());
-            if (zoneName != null) {
-                properties.put("zone", zoneName);
-            }
-
-            int zoneId = component.getTemperatureSensorForZoneId();
-            if (zoneId >= 0) {
-                String tempForZoneName = getZoneName(zoneId);
-                if (tempForZoneName != null) {
-                    properties.put("temperatureSensorForZone", tempForZoneName);
+            boolean addDiscoveredComponent = true;
+            for (Thing thing : things) {
+                if (thing.getUID().equals(discoveredThingId)) {
+                    addDiscoveredComponent = false;
                 }
             }
 
-            logger.debug("Adding device {} to inbox", thingId);
-            DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingId).withBridge(bridge)
-                    .withLabel(label).withProperties(properties).withRepresentationProperty("serialNumber").build();
-            thingDiscovered(discoveryResult);
+            if (addDiscoveredComponent) {
+                String label = component.getName();
+
+                Map<String, Object> properties = new HashMap<>(1);
+                properties.put("serialNumber", component.getSerialNumber().toString());
+                properties.put("name", component.getName());
+                properties.put("vendor", VENDOR);
+                properties.put("model", component.getSerialNumber().getComponentType());
+
+                String zoneName = getZoneName(component.getZoneId());
+                if (zoneName != null) {
+                    properties.put("zone", zoneName);
+                }
+
+                int zoneId = component.getTemperatureSensorForZoneId();
+                if (zoneId >= 0) {
+                    String tempForZoneName = getZoneName(zoneId);
+                    if (tempForZoneName != null) {
+                        properties.put("temperatureSensorForZone", tempForZoneName);
+                    }
+                }
+
+                logger.debug("Adding device {} to inbox", discoveredThingId);
+                DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(discoveredThingId).withBridge(bridge)
+                        .withLabel(label).withProperties(properties).withRepresentationProperty("serialNumber").build();
+                thingDiscovered(discoveryResult);
+            }
         }
     }
 

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/discovery/NoboThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/discovery/NoboThingDiscoveryService.java
@@ -102,12 +102,15 @@ public class NoboThingDiscoveryService extends AbstractDiscoveryService {
             if (zoneName != null) {
                 properties.put("zone", zoneName);
             }
-        
-            String tempForZoneName = getZoneName(component.getTemperatureSensorForZoneId());
-            if (tempForZoneName != null) {
-                properties.put("temperatureSensorForZone", tempForZoneName);
+
+            int zoneId = component.getTemperatureSensorForZoneId();
+            if (zoneId >= 0) {
+                String tempForZoneName = getZoneName(zoneId);
+                if (tempForZoneName != null) {
+                    properties.put("temperatureSensorForZone", tempForZoneName);
+                }
             }
-        
+
             logger.debug("Adding device {} to inbox", thingId);
             DiscoveryResult discoveryResult = DiscoveryResultBuilder.create(thingId).withBridge(bridge)
                     .withLabel(label).withProperties(properties).withRepresentationProperty("serialNumber").build();

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/discovery/NoboThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/discovery/NoboThingDiscoveryService.java
@@ -1,13 +1,13 @@
 /**
  * Copyright (c) 2010-2020 Contributors to the openHAB project
- * <p>
+ *
  * See the NOTICE file(s) distributed with this work for additional
  * information.
- * <p>
+ *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0
- * <p>
+ *
  * SPDX-License-Identifier: EPL-2.0
  */
 package org.openhab.binding.nobohub.internal.discovery;

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/model/WeekProfileStatus.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/model/WeekProfileStatus.java
@@ -13,8 +13,11 @@
 package org.openhab.binding.nobohub.internal.model;
 
 /**
- * The status of the {@link WeekProfile}. What the value is in the week profile.
- * 
+ * The status of the {@link WeekProfile}. What the value is in the week profile. Status OFF is matched both to value 3
+ * and 4, while the documentation says 3, Hub with Hardware version 11123610_rev._1 and production date 20180305
+ * will send value 4 for OFF.
+ * compatibility.
+ *
  * @author Jørgen Austvik - Initial contribution
  */
 public enum WeekProfileStatus {
@@ -36,7 +39,9 @@ public enum WeekProfileStatus {
             case 0: return ECO;
             case 1: return COMFORT;
             case 2: return AWAY;
-            case 3: return OFF;
+            case 3:
+            case 4:
+                return OFF;
             default: throw new NoboDataException(String.format("Unknown week profile status  %d", value));
         }
     }

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/model/Zone.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/model/Zone.java
@@ -16,8 +16,8 @@ import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
 
 /**
- * A Zone is a spece that contains one or more {@link Component}s.
- * 
+ * A Zone is a spec that contains one or more {@link Component}s.
+ *
  * @author Jørgen Austvik - Initial contribution
  */
 @NonNullByDefault
@@ -25,7 +25,7 @@ public final class Zone {
 
     private final int id;
     private final String name;
-    private final int activeWeekProfileId;
+    private int activeWeekProfileId;
     private int comfortTemperature;
     private int ecoTemperature;
     private final boolean allowOverrides;
@@ -57,7 +57,7 @@ public final class Zone {
     }
 
     public String generateCommandString(final String command) {
-        return String.join(" ", 
+        return String.join(" ",
             command,
             Integer.toString(id),
             ModelHelper.toHubString(name),
@@ -106,5 +106,9 @@ public final class Zone {
 
     public void setEcoTemperature(int temp) {
         ecoTemperature = temp;
+    }
+
+    public void setWeekProfile(int weekProfileId) {
+        activeWeekProfileId = weekProfileId;
     }
 }

--- a/bundles/org.openhab.binding.nobohub/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nobohub/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -45,7 +45,7 @@
 
 		<channels>
 			<channel id="activeWeekProfileName" typeId="activeWeekProfileName-channel-type" />
-			<channel id="activeWeekProfile" typeId="activeWeekProfileName-channel-type" />
+			<channel id="activeWeekProfile" typeId="activeWeekProfile-channel-type" />
 			<channel id="comfortTemperature" typeId="comfort-temperature-channel-type" />
 			<channel id="ecoTemperature" typeId="eco-temperature-channel-type" />
 			<channel id="currentTemperature" typeId="temperature-channel-type" />

--- a/bundles/org.openhab.binding.nobohub/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.nobohub/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -10,6 +10,7 @@
 
 		<channels>
 			<channel id="activeOverrideName" typeId="activeOverrideName-channel-type" />
+			<channel id="weekProfiles" typeId="weekProfiles-channel-type" />
 		</channels>
 
 		<properties>
@@ -41,9 +42,10 @@
 
 		<label>Zone</label>
 		<description>A zone can contain several Nobo devices</description>
-	
+
 		<channels>
-			<channel id="activeWeekProfile" typeId="weekProfileName-channel-type" />
+			<channel id="activeWeekProfileName" typeId="activeWeekProfileName-channel-type" />
+			<channel id="activeWeekProfile" typeId="activeWeekProfileName-channel-type" />
 			<channel id="comfortTemperature" typeId="comfort-temperature-channel-type" />
 			<channel id="ecoTemperature" typeId="eco-temperature-channel-type" />
 			<channel id="currentTemperature" typeId="temperature-channel-type" />
@@ -70,7 +72,7 @@
 
 		<label>Component</label>
 		<description>A component is an oven, a switch or a floor termostat</description>
-	
+
 		<channels>
 			<channel id="currentTemperature" typeId="temperature-channel-type" />
 		</channels>
@@ -132,9 +134,23 @@
 		<state pattern="%.3f °C" readOnly="true" />
 	</channel-type>
 
-	<channel-type id="weekProfileName-channel-type">
+	<channel-type id="activeWeekProfileName-channel-type">
 		<item-type>String</item-type>
-		<label>Week Profile</label>
+		<label>Active Week Profile Name</label>
+		<category>Week Profile</category>
+		<state readOnly="true" />
+	</channel-type>
+
+	<channel-type id="activeWeekProfile-channel-type">
+		<item-type>Number</item-type>
+		<label>Active Week Profile Id</label>
+		<category>Week Profile</category>
+		<state min="0" readOnly="false" />
+	</channel-type>
+
+	<channel-type id="weekProfiles-channel-type">
+		<item-type>String</item-type>
+		<label>Week Profiles</label>
 		<category>Week Profile</category>
 		<state readOnly="true" />
 	</channel-type>

--- a/bundles/org.openhab.binding.nobohub/src/test/java/org/openhab/binding/nobohub/internal/model/WeekProfileTest.java
+++ b/bundles/org.openhab.binding.nobohub/src/test/java/org/openhab/binding/nobohub/internal/model/WeekProfileTest.java
@@ -22,7 +22,7 @@ import org.junit.Test;
 
 /**
  * Unit tests for WeekProfile model object.
- * 
+ *
  * @author Jørgen Austvik - Initial contribution
  */
 @NonNullByDefault
@@ -59,6 +59,15 @@ public class WeekProfileTest {
         WeekProfile weekProfile = WeekProfile.fromH03("H03 1 Default 00000,00000,00001,00000,00000,00000,00000");
         WeekProfileStatus status = weekProfile.getStatusAt(WEDNESDAY);
         assertEquals(WeekProfileStatus.COMFORT, status);
+    }
+
+    @Test
+    public void testFindOffDayStatus() throws NoboDataException {
+        WeekProfile weekProfile = WeekProfile.fromH03("H03 2 Off 00004,00003,00004,00004,00004,00004,00003");
+        WeekProfileStatus statusWen = weekProfile.getStatusAt(WEDNESDAY);
+        assertEquals(WeekProfileStatus.OFF, statusWen);
+        WeekProfileStatus statusSat = weekProfile.getStatusAt(SUNDAY);
+        assertEquals(WeekProfileStatus.OFF, statusSat);
     }
 
     @Test


### PR DESCRIPTION
A cold winter made me finally fix all the issues I have had with the binding. Also adding the ability to choose week profile for each zone. Here is a compiled changelog.

* Added week profile selection for zone. Changes activeWeekProfile to a changeable number type, while also adding activeWeekProfileName for the actual label. 
* Updated README with examples.
* Fixed issue with temperatureSensorForZoneID being -1 if not present in component. 
* Fixed issue with zones being offline after restart. 
* Fixed issue with Week Profile status values of 4 instead of 3 for OFF type.
* Improved discovery to only add devices not already added. 
* Hard reconnect does a full connect instead of only connectSocket, which does not always work.