### PR TITLE
Dynamically updating Week Profile options via DynamicStateDescriptionProvider

### DIFF
--- a/bundles/org.openhab.binding.nobohub/README.md
+++ b/bundles/org.openhab.binding.nobohub/README.md
@@ -53,6 +53,7 @@ hostName=10.0.0.10
 | channel             | type   | description                      |
 |---------------------|--------|----------------------------------|
 | activeOverrideName  | String | The name of the active override  |
+| weekProfiles        | String | Week profiles  |
 
 ### Zone
 
@@ -129,7 +130,7 @@ sitemap nobo label="Nobø " {
 ## Organize your setup
 
 Nobø Hub uses a combination of status types (Normal, Comfort, Eco, Away), profiles types (Comfort, Eco, Away, Off), 
-temperatures types (Comfort, Eco, Away), zones and overrides settings to organize and enable different features. 
+predfined temperature types (Comfort, Eco, Away), zones and override settings to organize and enable different features. 
 This makes it possible to control the heaters in many different scenarios and combinations. The following is a suggested
 way of organizing the binding with the Hub for a good level of control and flexibility.
 
@@ -153,7 +154,7 @@ Next set [Comfort|Eco] level for each zone to your requirements. For a more adva
 both sets temperature level and profile.
 
 Get list of profile id's and names either from the logs or adding item Nobo_Hub_WeekProfiles to a sitemap. As the string
-can be quite long, using the logs are recommended. Now map the id="Profile name" to a switch og selection like this
+can be quite long, using the logs are recommended. Now map the id="Profile name" to a switch or selection like this:
 
 
 ### nobo.sitemap

--- a/bundles/org.openhab.binding.nobohub/README.md
+++ b/bundles/org.openhab.binding.nobohub/README.md
@@ -50,10 +50,10 @@ hostName=10.0.0.10
 
 ### Hub
 
-| channel             | type   | description                      |
-|---------------------|--------|----------------------------------|
-| activeOverrideName  | String | The name of the active override  |
-| weekProfiles        | String | Week profiles  |
+| channel             | type   | description                                         |
+|---------------------|--------|-----------------------------------------------------|
+| activeOverrideName  | String | The name of the active override                     |
+| weekProfiles        | String | List of present week profiles (0="Default", 1="On") |
 
 ### Zone
 

--- a/bundles/org.openhab.binding.nobohub/README.md
+++ b/bundles/org.openhab.binding.nobohub/README.md
@@ -163,7 +163,7 @@ can be quite long, using the logs are recommended. Now map the id="Profile name"
 sitemap nobo label="Nobø " {
 
     Frame label="Main Bedroom"{
-      Selection item=MainBedroom_Zone_WeekProfil  mappings=[0=Default, 1="OFF", 2="On", 2="Eco", 3="Away", 
+      Selection item=MainBedroom_Zone_WeekProfile  mappings=[0="Default", 1="OFF", 2="On", 2="Eco", 3="Away", 
       4="Weekday 06->16", 5="Weekday 06->23", 6="Weekend 06->16", 7="Weekend 06->23", 8="Weekend 06->16", 
       9="Every day 06->16", 10="Every day 06->23"]    
     }

--- a/bundles/org.openhab.binding.nobohub/README.md
+++ b/bundles/org.openhab.binding.nobohub/README.md
@@ -53,7 +53,6 @@ hostName=10.0.0.10
 | channel             | type   | description                                         |
 |---------------------|--------|-----------------------------------------------------|
 | activeOverrideName  | String | The name of the active override                     |
-| weekProfiles        | String | List of present week profiles (0="Default", 1="On") |
 
 ### Zone
 
@@ -92,14 +91,13 @@ Bridge nobohub:nobohub:controller "Nobø Hub" [ hostName="192.168.1.10", serialN
 ```
 // Hub
 String	Nobo_Hub_GlobalOverride         "Global Override %s"                <heating>       {channel="nobohub:nobohub:controller:activeOverrideName"}
-String	Nobo_Hub_WeekProfiles           "Week profiles %s"                  <calendar>      {channel="nobohub:nobohub:controller:weekProfiles"}
 
 // Panel Heater
 Number	PanelHeater_CurrentTemperatur   "Setpoint [%.1f °C]"                <temperature>   {channel="nobohub:component:controller:SERIAL_NUMBER_COMPONENT:currentTemperature"}
 
 // Zone
 String	Zone_ActiveWeekProfileName      "Active week profile name [%s]"     <calendar>      {channel="nobohub:zone:controller:1:activeWeekProfileName"}
-NUmber	Zone_ActiveWeekProfile          "Active week profile [%d]"          <calendar>      {channel="nobohub:zone:controller:1:activeWeekProfile"}
+Number	Zone_ActiveWeekProfile          "Active week profile [%d]"          <calendar>      {channel="nobohub:zone:controller:1:activeWeekProfile"}
 String	Zone_ActiveStatus               "Active status %s]"                 <heating>       {channel="nobohub:zone:controller:1:calculatedWeekProfileStatus"}
 Number	Zone_ComfortTemperatur          "Comfort temperature [%.1f °C]"     <temperature>   {channel="nobohub:zone:controller:1:comfortTemperature"}
 Number	Zone_EcoTemperatur              "Eco temperature [%.1f °C]"         <temperature>   {channel="nobohub:zone:controller:1:ecoTemperature"}
@@ -119,6 +117,7 @@ sitemap nobo label="Nobø " {
       Switch    item=Zone_ActiveStatus
       Text      item=Zone_ActiveWeekProfileName           
       Text      item=Zone_ActiveWeekProfile           
+      Selection item=Zone_ActiveWeekProfile           
       Setpoint  item=Zone_ComfortTemperatur minValue=7 maxValue=30 step=1 icon="temperature"
       Setpoint  item=Zone_EcoTemperatur     minValue=7 maxValue=30 step=1 icon="temperature"
       Text      item=Zone_CurrentTemperatur
@@ -153,9 +152,8 @@ Start på creating the following profiles in the Nobø Hub App:
 Next set [Comfort|Eco] level for each zone to your requirements. For a more advanced setup, you can create a rule which 
 both sets temperature level and profile.
 
-Get list of profile id's and names either from the logs or adding item Nobo_Hub_WeekProfiles to a sitemap. As the string
-can be quite long, using the logs are recommended. Now map the id="Profile name" to a switch or selection like this:
-
+Then create a sitemap with a Selection pointing to the Week Profile item. The binding will now automatically update all 
+available week profile options in the selection button:
 
 ### nobo.sitemap
 
@@ -163,9 +161,7 @@ can be quite long, using the logs are recommended. Now map the id="Profile name"
 sitemap nobo label="Nobø " {
 
     Frame label="Main Bedroom"{
-      Selection item=MainBedroom_Zone_WeekProfile  mappings=[0="Default", 1="OFF", 2="On", 2="Eco", 3="Away", 
-      4="Weekday 06->16", 5="Weekday 06->23", 6="Weekend 06->16", 7="Weekend 06->23", 8="Weekend 06->16", 
-      9="Every day 06->16", 10="Every day 06->23"]    
+      Selection item=MainBedroom_Zone_WeekProfile   
     }
 }
 ```

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBindingConstants.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBindingConstants.java
@@ -30,6 +30,7 @@ import org.eclipse.smarthome.core.thing.ThingTypeUID;
  * used across the whole binding.
  *
  * @author Jørgen Austvik - Initial contribution
+ * @author Espen Fossen - Added support for week profile
  */
 @NonNullByDefault
 public class NoboHubBindingConstants {
@@ -59,7 +60,6 @@ public class NoboHubBindingConstants {
 
     // Hub
     public static final String CHANNEL_HUB_ACTIVE_OVERRIDE_NAME = "activeOverrideName";
-    public static final String CHANNEL_HUB_WEEK_PROFILES = "weekProfiles";
 
     // Zone
     public static final String CHANNEL_ZONE_ACTIVE_WEEK_PROFILE_NAME = "activeWeekProfileName";

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBridgeHandler.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBridgeHandler.java
@@ -12,12 +12,12 @@
  */
 package org.openhab.binding.nobohub.internal;
 
-import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.*;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.CHANNEL_HUB_ACTIVE_OVERRIDE_NAME;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
@@ -38,13 +38,13 @@ import org.openhab.binding.nobohub.internal.connection.HubConnection;
 import org.openhab.binding.nobohub.internal.discovery.NoboThingDiscoveryService;
 import org.openhab.binding.nobohub.internal.model.Component;
 import org.openhab.binding.nobohub.internal.model.Hub;
+import org.openhab.binding.nobohub.internal.model.NoboCommunicationException;
+import org.openhab.binding.nobohub.internal.model.NoboDataException;
 import org.openhab.binding.nobohub.internal.model.Override;
 import org.openhab.binding.nobohub.internal.model.OverrideMode;
 import org.openhab.binding.nobohub.internal.model.SerialNumber;
 import org.openhab.binding.nobohub.internal.model.WeekProfile;
 import org.openhab.binding.nobohub.internal.model.Zone;
-import org.openhab.binding.nobohub.internal.model.NoboCommunicationException;
-import org.openhab.binding.nobohub.internal.model.NoboDataException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +53,7 @@ import org.slf4j.LoggerFactory;
  * sent to one of the channels.
  *
  * @author Jørgen Austvik - Initial contribution
+ * @author Espen Fossen - Fixes
  */
 @NonNullByDefault
 public class NoboHubBridgeHandler extends BaseBridgeHandler {
@@ -218,23 +219,6 @@ public class NoboHubBridgeHandler extends BaseBridgeHandler {
         if (null != activeOverride) {
             Override o = Helpers.castToNonNull(activeOverride, "activeOverride");
             updateState(NoboHubBindingConstants.CHANNEL_HUB_ACTIVE_OVERRIDE_NAME, StringType.valueOf(o.getMode().name()));
-        }
-
-
-        if(weekProfileRegister.size() > 0){
-            String mapOfWeekProfilesToString = weekProfileRegister.values()
-                    .stream()
-                    .map(weekProfile -> weekProfile.getId() + "=\"" + weekProfile.getName() + "\"")
-                    .collect(Collectors.joining(", "));
-            logger.info("Found profiles: {}", mapOfWeekProfilesToString);
-
-            Bridge noboHub = getBridge();
-            if (null != noboHub) {
-                NoboHubBridgeHandler hubHandler = (NoboHubBridgeHandler) noboHub.getHandler();
-                if (hubHandler != null) {
-                    updateState(NoboHubBindingConstants.CHANNEL_HUB_WEEK_PROFILES, StringType.valueOf(mapOfWeekProfilesToString));
-                }
-            }
         }
 
         // Update all zones to set online status and update profile name from weekProfileRegister
@@ -439,5 +423,9 @@ public class NoboHubBridgeHandler extends BaseBridgeHandler {
 
     public void setDicsoveryService(NoboThingDiscoveryService discoveryService) {
         this.discoveryService = discoveryService;
+    }
+
+    public Collection<WeekProfile> getWeekProfiles() {
+        return weekProfileRegister.values();
     }
 }

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBridgeHandler.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubBridgeHandler.java
@@ -16,8 +16,6 @@ import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.CHANN
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
 import javax.validation.constraints.NotNull;
 
@@ -50,8 +48,6 @@ import org.openhab.binding.nobohub.internal.model.WeekProfile;
 import org.openhab.binding.nobohub.internal.model.WeekProfileRegister;
 import org.openhab.binding.nobohub.internal.model.Zone;
 import org.openhab.binding.nobohub.internal.model.ZoneRegister;
-import org.openhab.binding.nobohub.internal.model.NoboCommunicationException;
-import org.openhab.binding.nobohub.internal.model.NoboDataException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubHandlerFactory.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/NoboHubHandlerFactory.java
@@ -12,7 +12,10 @@
  */
 package org.openhab.binding.nobohub.internal;
 
-import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.*;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.SUPPORTED_THING_TYPES_UIDS;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.THING_TYPE_COMPONENT;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.THING_TYPE_HUB;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.THING_TYPE_ZONE;
 
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -31,6 +34,7 @@ import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.nobohub.internal.discovery.NoboThingDiscoveryService;
 import org.osgi.framework.ServiceRegistration;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +43,7 @@ import org.slf4j.LoggerFactory;
  * handlers.
  *
  * @author Jørgen Austvik - Initial contribution
+ * @author Espen Fossen - Added support for week profile
  */
 @NonNullByDefault
 @Component(configurationPid = "binding.nobohub", service = ThingHandlerFactory.class)
@@ -46,6 +51,7 @@ public class NoboHubHandlerFactory extends BaseThingHandlerFactory {
 
     private final Logger logger = LoggerFactory.getLogger(NoboHubHandlerFactory.class);
     private final Map<ThingUID, ServiceRegistration<?>> discoveryServiceRegs = new HashMap<>();
+    private @NonNullByDefault({}) WeekProfileStateDescriptionOptionsProvider stateDescriptionOptionsProvider;
 
     @Override
     public boolean supportsThingType(ThingTypeUID thingTypeUID) {
@@ -61,7 +67,7 @@ public class NoboHubHandlerFactory extends BaseThingHandlerFactory {
             registerDiscoveryService(handler);
             return handler;
         } else if (THING_TYPE_ZONE.equals(thingTypeUID)) {
-            return new ZoneHandler(thing);
+            return new ZoneHandler(thing, stateDescriptionOptionsProvider);
         } else if (THING_TYPE_COMPONENT.equals(thingTypeUID)) {
             return new ComponentHandler(thing);
         }
@@ -98,5 +104,14 @@ public class NoboHubHandlerFactory extends BaseThingHandlerFactory {
         } catch (IllegalArgumentException iae) {
             logger.error("Failed to unregister service", iae);
         }
+    }
+
+    @Reference
+    protected void setDynamicStateDescriptionProvider(WeekProfileStateDescriptionOptionsProvider provider) {
+        this.stateDescriptionOptionsProvider = provider;
+    }
+
+    protected void unsetDynamicStateDescriptionProvider(WeekProfileStateDescriptionOptionsProvider provider) {
+        this.stateDescriptionOptionsProvider = null;
     }
 }

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/WeekProfileStateDescriptionOptionsProvider.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/WeekProfileStateDescriptionOptionsProvider.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2010-2020 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.nobohub.internal;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.smarthome.core.thing.binding.BaseDynamicStateDescriptionProvider;
+import org.eclipse.smarthome.core.thing.i18n.ChannelTypeI18nLocalizationService;
+import org.eclipse.smarthome.core.thing.type.DynamicStateDescriptionProvider;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * Dynamic provider of week profile state options .
+ *
+ * @author Espen Fossen - Initial contribution
+ */
+@Component(service = { DynamicStateDescriptionProvider.class, WeekProfileStateDescriptionOptionsProvider.class })
+@NonNullByDefault
+public class WeekProfileStateDescriptionOptionsProvider extends BaseDynamicStateDescriptionProvider {
+
+    @Reference
+    protected void setChannelTypeI18nLocalizationService(
+            final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+        this.channelTypeI18nLocalizationService = channelTypeI18nLocalizationService;
+    }
+
+    protected void unsetChannelTypeI18nLocalizationService(
+            final ChannelTypeI18nLocalizationService channelTypeI18nLocalizationService) {
+        this.channelTypeI18nLocalizationService = null;
+    }
+
+}

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/ZoneHandler.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/ZoneHandler.java
@@ -12,9 +12,16 @@
  */
 package org.openhab.binding.nobohub.internal;
 
-import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.*;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.CHANNEL_ZONE_ACTIVE_WEEK_PROFILE;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.CHANNEL_ZONE_ACTIVE_WEEK_PROFILE_NAME;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.CHANNEL_ZONE_CALCULATED_WEEK_PROFILE_STATUS;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.CHANNEL_ZONE_COMFORT_TEMPERATURE;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.CHANNEL_ZONE_CURRENT_TEMPERATURE;
+import static org.openhab.binding.nobohub.internal.NoboHubBindingConstants.CHANNEL_ZONE_ECO_TEMPERATURE;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.jdt.annotation.NonNullByDefault;
 import org.eclipse.jdt.annotation.Nullable;
@@ -28,6 +35,7 @@ import org.eclipse.smarthome.core.thing.ThingStatusDetail;
 import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
 import org.eclipse.smarthome.core.types.Command;
 import org.eclipse.smarthome.core.types.RefreshType;
+import org.eclipse.smarthome.core.types.StateOption;
 import org.openhab.binding.nobohub.internal.model.NoboDataException;
 import org.openhab.binding.nobohub.internal.model.WeekProfile;
 import org.openhab.binding.nobohub.internal.model.WeekProfileStatus;
@@ -39,16 +47,20 @@ import org.slf4j.LoggerFactory;
  * Shows information about a named Zone in the Nobø Hub.
  *
  * @author Jørgen Austvik - Initial contribution
+ * @author Espen Fossen - Added support for week profile
  */
 @NonNullByDefault
 public class ZoneHandler extends BaseThingHandler {
 
     private final Logger logger = LoggerFactory.getLogger(ZoneHandler.class);
 
+    private final WeekProfileStateDescriptionOptionsProvider weekProfileStateDescriptionOptionsProvider;
+
     protected @Nullable Integer id;
 
-    public ZoneHandler(Thing thing) {
+    public ZoneHandler(Thing thing, WeekProfileStateDescriptionOptionsProvider weekProfileStateDescriptionOptionsProvider) {
         super(thing);
+        this.weekProfileStateDescriptionOptionsProvider = weekProfileStateDescriptionOptionsProvider;
     }
 
     public void onUpdate(Zone zone) {
@@ -81,6 +93,13 @@ public class ZoneHandler extends BaseThingHandler {
                         logger.error("Failed getting current week profile status", nde);
                     }
                 }
+
+                List<StateOption> options = new ArrayList<>();
+                logger.debug("Updating week profile state description options for zone {}.", zone.getName());
+                for (WeekProfile wp : hubHandler.getWeekProfiles()) {
+                    options.add(new StateOption(String.valueOf(wp.getId()), wp.getName()));
+                }
+                weekProfileStateDescriptionOptionsProvider.setStateOptions(new ChannelUID(getThing().getUID(), CHANNEL_ZONE_ACTIVE_WEEK_PROFILE), options);
             }
         }
 

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/discovery/NoboThingDiscoveryService.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/discovery/NoboThingDiscoveryService.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
  * This class identifies devices that are available on the Nobø hub and adds discovery results for them.
  *
  * @author Jørgen Austvik - Initial contribution
+ * @author Espen Fossen - Fixes
  */
 @NonNullByDefault
 public class NoboThingDiscoveryService extends AbstractDiscoveryService {

--- a/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/model/WeekProfileRegister.java
+++ b/bundles/org.openhab.binding.nobohub/src/main/java/org/openhab/binding/nobohub/internal/model/WeekProfileRegister.java
@@ -12,10 +12,9 @@
  */
 package org.openhab.binding.nobohub.internal.model;
 
-import java.util.Comparator;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import javax.validation.constraints.NotNull;
 
@@ -24,7 +23,7 @@ import org.eclipse.jdt.annotation.Nullable;
 
 /**
  * Stores a mapping between week profile ids and week profiles that exists.
- * 
+ *
  * @author Jørgen Austvik - Initial contribution
  */
 @NonNullByDefault
@@ -34,16 +33,16 @@ public final class WeekProfileRegister {
 
     /**
      * Stores a new week profile in the register. If an week profile exists with the same id, that value is overwritten.
-     * 
+     *
      * @param profile The week profile to store.
      */
     public void put(WeekProfile profile) {
-        register.put(profile.getId(), profile);        
+        register.put(profile.getId(), profile);
     }
 
     /**
-     * Removes a WeekProfile from the registry. 
-     * 
+     * Removes a WeekProfile from the registry.
+     *
      * @param weekProfileId The week profile to remove
      * @return The week profile that is removed. Null if the week profile is not found.
      */
@@ -53,28 +52,25 @@ public final class WeekProfileRegister {
 
     /**
      * Returns a WeekProfile from the registry.
-     * 
+     *
      * @param weekProfileId The id of the week profile to return.
-     * @return Returns the week profile, or null if it doesnt exist in the regestry.
+     * @return Returns the week profile, or null if it doesnt exist in the registry.
      */
     public @Nullable WeekProfile get(int weekProfileId) {
-        return register.get(weekProfileId);     
+        return register.get(weekProfileId);
+    }
+
+    /**
+     * Returns all WeekProfiles from the registry.
+     *
+     * @return Returns the week profile, or empty list if no profiles.
+     */
+    public Collection<WeekProfile> values() {
+        return register.values();
     }
 
     public boolean isEmpty() {
         return register.isEmpty();
-    }
-
-    public String getProfileMapString() {
-        if (isEmpty()) {
-            return "<no week profiles>";
-        }
-
-        return register.values()
-            .stream()
-            .sorted(Comparator.comparingInt(WeekProfile::getId))
-            .map(weekProfile -> weekProfile.getId() + "=\"" + weekProfile.getName() + "\"")
-            .collect(Collectors.joining(", "));        
     }
 
 }

--- a/bundles/org.openhab.binding.nobohub/src/test/java/org/openhab/binding/nobohub/internal/model/WeekProfileRegisterTest.java
+++ b/bundles/org.openhab.binding.nobohub/src/test/java/org/openhab/binding/nobohub/internal/model/WeekProfileRegisterTest.java
@@ -75,15 +75,4 @@ public class WeekProfileRegisterTest {
         assertEquals(false, sut.isEmpty());
     }
 
-    @Test
-    public void testProfileMapString() throws NoboDataException {
-        WeekProfile p1 = WeekProfile.fromH03("H03 1 Default 00000,06001,08000,15001,23000,00000,06001,08000,15001,23000,00000,06001,08000,15001,23000,00000,06001,08000,15001,23000,00000,06001,08000,15001,00000,07001,00000,07001,23000");
-        WeekProfile p2 = WeekProfile.fromH03("H03 2 HomeOffice 00000,06001,09000,15001,23000,00000,06001,08000,15001,23000,00000,06001,08000,15001,23000,00000,06001,08000,15001,23000,00000,06001,08000,15001,00000,07001,00000,07001,23000");
-        WeekProfileRegister sut = new WeekProfileRegister();
-        assertEquals("<no week profiles>", sut.getProfileMapString());
-        sut.put(p1);
-        sut.put(p2);
-        assertEquals("1=\"Default\", 2=\"HomeOffice\"", sut.getProfileMapString());
-    }
-
 }


### PR DESCRIPTION
<!--
Thanks for contributing to the openHAB project!
Please describe the goal and effect of your PR here.
Pay attention to the below notes and to *the guidelines* for this repository.
Feel free to delete any comment sections in the template (starting with "<!--").
-->

<!-- TITLE -->

<!--
Please provide a PR summary in the *Title* above, according to the following schema:
- If related to one specific add-on: Mention the add-on shortname in square brackets
  e.g. "[exec]", "[netatmo]" or "[tesla]"
- If the PR is work in progress: Add "[WIP]"
- Give a short meaningful description in imperative mood
  e.g. "Add support for device XYZ" or "Fix wrongly handled exception"
  for a new add-on/binding: "Initial contribution"
Examples:
- "[homematic] Improve communication with weak signal devices"
- "[timemachine][WIP] Initial contribution"
- "Update contribution guidelines on new signing rules"
-->

<!-- DESCRIPTION -->

<!--
Please give a few sentences describing the overall goals of the pull request.
Give enough details to make the improvement and changes of the PR understandable
to both developers and tech-savy users.

Please keep the following in mind:
- What is the classification of the PR, e.g. Bugfix, Improvement, Novel Addition, ... ?
- Did you describe the PRs motivation and goal?
- Did you provide a link to any prior discussion, e.g. an issue or community forum thread?
- Did you describe new features for the end user?
- Did you describe any noteworthy changes in usage for the end user?
- Was the documentation updated accordingly, e.g. the add-on README?
- Does your contribution follow the coding guidelines:
  https://www.openhab.org/docs/developer/development/guidelines.html
- Did you check for any (relevant) issues from the static code analysis:
  https://www.openhab.org/docs/developer/development/bindings.html#static-code-analysis
- Did you sign-off your work:
  https://www.openhab.org/docs/developer/contributing/contributing.html#sign-your-work
-->

<!-- TESTING -->

<!--
Your Pull Request will automatically be built and available under the following folder:
https://openhab.jfrog.io/openhab/libs-pullrequest-local/org/openhab/

It is a good practice to add a URL to your built JAR in this Pull Request description,
so it is easier for the community to test your Add-on.
If your Pull Request contains a new binding, it will likely take some time
before it is reviewed and processed by maintainers.
That said, consider submitting your Add-on in the Eclipse IoT Marketplace
See this thread for more info:
https://community.openhab.org/t/24491

Don't forget to submit a thread about your Add-on in the openHAB community:
https://community.openhab.org/c/add-ons 
-->

Does not require manual setup of selection mapping anymore when using a DynamicStateDescriptionProvider to populate week profiles on the fly. This fixes the issues I had with exposing Week Profiles in a good way. Now the user can just edit them in the app, and get updates directly in the sitemap.
